### PR TITLE
Fix build-subreddit-url.

### DIFF
--- a/src/reddit/clj/client.clj
+++ b/src/reddit/clj/client.clj
@@ -44,8 +44,8 @@
 (defn- build-subreddit-url
   [rname qualifier rcount since]
     (str "http://www.reddit.com" 
-      (and rname (str "/r/" rname "/"))
-      (str qualifier "/")
+      (and rname (str "/r/" rname))
+      (str "/" qualifier "/")
       ".json" 
       (build-pagination-param rcount since)))
 


### PR DESCRIPTION
Calling `reddit/reddits-new` (or `controversial` and `top`) with a `nil` subreddit returns an invalid URL (e.g. http://reddit.comnew).
